### PR TITLE
Add Paul Brigner's X account

### DIFF
--- a/_staff_members/paul.md
+++ b/_staff_members/paul.md
@@ -2,6 +2,7 @@
 name: Paul Brigner
 position: Committee Member
 image_path: ../images/paul.jpg
+twitter: paulbrigner
 ---
 
 Paul Brigner is Chief Policy & Regulatory Officer at Zcash Open Development Lab (Zodl), founder and organizer of PGP* (Pretty Good Policy) for Crypto, and Adjunct Faculty of FinTech at Georgetown University. He is a technology policy executive, former software developer, attorney, and U.S. Army veteran with experience spanning software engineering, internet governance, cryptocurrency policy, financial privacy, and public advocacy. His career has included senior roles at Verizon, Internet Society, the Motion Picture Association, the Chamber of Digital Commerce, Coinbase Institute, Electric Coin Co., Bootstrap, and Zodl. Through PGP* and the DC Privacy Summit, he convenes policymakers, builders, researchers, advocates, and industry leaders to advance discussion of crypto policy, privacy-preserving technologies, digital rights, and open financial systems. His work focuses on Zcash, financial privacy, and the future of digital cash.


### PR DESCRIPTION
Add the `twitter: paulbrigner` handle (https://x.com/paulbrigner) to Paul's committee profile, following up on #33.